### PR TITLE
（レベル1）特定の言葉に対応する固定メッセージを返す機能の追加

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -36,17 +36,7 @@ class WebhookController < ApplicationController
               type: 'text',
               text: 'サンホセ'
             }
-          elsif event.message['text'].eql?('JP') then
-            # JPと入力したら日本の2020年の祝日リストを返す
-            get_holidays(event.message['text'], '2020')
-            message = {
-              type: 'text',
-              text: holidays_list
-            }
           else
-            # Nager.Dateをコール
-            # api/v2/AvailableCountriesで辞書型リストゲット
-            # contrycodes={'code': 'name'}
             message = {
               type: 'text',
               text: event.message['text']
@@ -61,40 +51,5 @@ class WebhookController < ApplicationController
       end
     }
     head :ok
-  end
-
-  def get_holidays(countrycode, year, retry_count = 10)
-    raise ArgumentError, 'too many HTTP redirects' if retry_count == 0
-
-    uri = Addressable::URI.parse("https://date.nager.at/Api/v1/Get/#{countrycode}/#{year}")
-
-    begin
-      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
-        http.open_timeout = 5
-        http.read_timeout = 10
-        http.get(uri.request_uri)
-      end
-
-      case response
-        when Net::HTTPSuccess
-          json = JSON.parse(response.body)
-          if json['results_returned'] == 0
-            nil
-          else
-            json
-          end
-
-        when Net::HTTPRedirection
-          location = response['location']
-          Rails.logger.error(warn "redirected to #{location}")
-          search_area(form_words, start_date, end_date, retry_count - 1)
-        else
-          Rails.logger.error([uri.to_s, response.value].join(" : "))
-      end
-
-    rescue => e
-      Rails.logger.error(e.message)
-      raise e
-    end
   end
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -24,19 +24,31 @@ class WebhookController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
-          if event.message['text'].eql?('鳥')
-            birds = {
+          if event.message['text'].eql?('日本') then
+            message = {
               type: 'text',
-              text: 'Bird images'
+              text: '東京'
             }
-            client.reply_message(event['replyToken'], birds)
+          elsif event.message['text'].eql?('コスタリカ') then
+            message = {
+              type: 'text',
+              text: 'サンホセ'
+            }
+          elsif event.message['text'].eql?('Japan') then
+            message = {
+              type: 'text',
+              text: '鋭意実装中'
+            }
           else
+            # Nager.Dateをコール
+            # api/v2/AvailableCountriesで辞書型リストゲット
+            # contrycodes={'code': 'name'}
             message = {
               type: 'text',
               text: event.message['text']
             }
-            client.reply_message(event['replyToken'], message)
           end
+          client.reply_message(event['replyToken'], message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])
           tf = Tempfile.open("content")

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,4 +1,6 @@
 require 'line/bot'
+require 'httpclient'
+require 'json'
 
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
@@ -34,10 +36,32 @@ class WebhookController < ApplicationController
               type: 'text',
               text: 'サンホセ'
             }
-          elsif event.message['text'].eql?('Japan') then
+          elsif event.message['text'].eql?('JP') then
+            # 取得先URL
+            url_holiday = 'https://date.nager.at/Api/v1/Get/'
+
+            params = {
+              countrycode = 'JP'
+              year = '2020'
+            }
+
+            client = HTTPClient.new
+            request = client.get(url_holiday, params)
+            response = JSON.parse(require.body)
+
+            # 祝日保管用Array
+            holiday_list = []
+            # 応答メッセージ
+            res_holiday = {}
+
+            response.each do |res|
+              holiday_list.append res["name"]
+              res_holiday += res["name"]
+              res_holiday += "¥n"
+            end
             message = {
               type: 'text',
-              text: '鋭意実装中'
+              text: res_holiday
             }
           else
             # Nager.Dateをコール

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -24,11 +24,19 @@ class WebhookController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
-          message = {
-            type: 'text',
-            text: event.message['text']
-          }
-          client.reply_message(event['replyToken'], message)
+          if event.message['text'].eql?('鳥')
+            birds = {
+              type: 'text',
+              text: 'Bird images'
+            }
+            client.reply_message(event['replyToken'], birds)
+          else
+            message = {
+              type: 'text',
+              text: event.message['text']
+            }
+            client.reply_message(event['replyToken'], message)
+          end
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])
           tf = Tempfile.open("content")

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,14 +1,5 @@
 require 'line/bot'
 
-# 返すテキストメッセージの設定
-def set_message(text)
-  message = {
-    type: 'text',
-    text: text
-  }
-  return message
-end
-
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
 
@@ -52,5 +43,13 @@ class WebhookController < ApplicationController
       end
     }
     head :ok
+  end
+
+  # 返すテキストメッセージの設定
+  def set_message(text)
+    message = {
+      type: 'text',
+      text: text
+    }
   end
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,5 +1,14 @@
 require 'line/bot'
 
+# 返すテキストメッセージの設定
+def set_message(text)
+  message = {
+    type: 'text',
+    text: text
+  }
+  return message
+end
+
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
 
@@ -24,21 +33,15 @@ class WebhookController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
-          if event.message['text'].eql?('日本') then
-            message = {
-              type: 'text',
-              text: '東京'
-            }
-          elsif event.message['text'].eql?('コスタリカ') then
-            message = {
-              type: 'text',
-              text: 'サンホセ'
-            }
-          else
-            message = {
-              type: 'text',
-              text: event.message['text']
-            }
+          # 入力したテキストの取得
+          inputted_text = event.message['text']
+          case inputted_text
+          when '日本'
+            message = set_message('東京')
+          when'コスタリカ'
+            message = set_message('サンホセ')
+          else  # オウム返し
+            message = set_message(inputted_text)
           end
           client.reply_message(event['replyToken'], message)
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -37,31 +37,11 @@ class WebhookController < ApplicationController
               text: 'サンホセ'
             }
           elsif event.message['text'].eql?('JP') then
-            # 取得先URL
-            url_holiday = 'https://date.nager.at/Api/v1/Get/'
-
-            params = {
-              countrycode = 'JP'
-              year = '2020'
-            }
-
-            client = HTTPClient.new
-            request = client.get(url_holiday, params)
-            response = JSON.parse(require.body)
-
-            # 祝日保管用Array
-            holiday_list = []
-            # 応答メッセージ
-            res_holiday = {}
-
-            response.each do |res|
-              holiday_list.append res["name"]
-              res_holiday += res["name"]
-              res_holiday += "¥n"
-            end
+            # JPと入力したら日本の2020年の祝日リストを返す
+            get_holidays(event.message['text'], '2020')
             message = {
               type: 'text',
-              text: res_holiday
+              text: holidays_list
             }
           else
             # Nager.Dateをコール
@@ -81,5 +61,40 @@ class WebhookController < ApplicationController
       end
     }
     head :ok
+  end
+
+  def get_holidays(countrycode, year, retry_count = 10)
+    raise ArgumentError, 'too many HTTP redirects' if retry_count == 0
+
+    uri = Addressable::URI.parse("https://date.nager.at/Api/v1/Get/#{countrycode}/#{year}")
+
+    begin
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        http.open_timeout = 5
+        http.read_timeout = 10
+        http.get(uri.request_uri)
+      end
+
+      case response
+        when Net::HTTPSuccess
+          json = JSON.parse(response.body)
+          if json['results_returned'] == 0
+            nil
+          else
+            json
+          end
+
+        when Net::HTTPRedirection
+          location = response['location']
+          Rails.logger.error(warn "redirected to #{location}")
+          search_area(form_words, start_date, end_date, retry_count - 1)
+        else
+          Rails.logger.error([uri.to_s, response.value].join(" : "))
+      end
+
+    rescue => e
+      Rails.logger.error(e.message)
+      raise e
+    end
   end
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,6 +1,4 @@
 require 'line/bot'
-require 'httpclient'
-require 'json'
 
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化


### PR DESCRIPTION
## 実装の背景・目的

LINE botの挙動を編集する方法を知るため

## やったこと

- レベル1：特定の言葉を入力すると対応する固定メッセージを返す
　最終的には入力は国名なので，とりあえず国名を入力すると首都名を返すようにしました．
　日本→東京
　コスタリカ→サンホセ

## キャプチャ

<img src="https://user-images.githubusercontent.com/48690396/77392702-e3309280-6dde-11ea-8900-2155e7bf497e.jpg" alt="lv1_screenshot" width="320px">
