### PR TITLE
レベル2：国コードを入力するとその国の祝日リストを返す機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,3 +44,5 @@ gem 'sinatra'
 gem 'bootsnap', require: false
 
 gem 'listen', group: :development
+
+gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.3.0)
     line-bot-api (1.13.0)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -196,6 +197,7 @@ DEPENDENCIES
   coffee-rails
   jbuilder
   jquery-rails
+  json
   line-bot-api
   listen
   pg (~> 0.18)

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,13 +1,5 @@
 require 'line/bot'
-
-# 返すテキストメッセージの設定
-def set_message(text)
-  message = {
-    type: 'text',
-    text: text
-  }
-  return message
-end
+require 'json'
 
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
@@ -33,17 +25,8 @@ class WebhookController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
-          # 入力したテキストの取得
-          inputted_text = event.message['text']
-          case inputted_text
-          when '日本'
-            message = set_message('東京')
-          when'コスタリカ'
-            message = set_message('サンホセ')
-          else  # オウム返し
-            message = set_message(inputted_text)
-          end
-          client.reply_message(event['replyToken'], message)
+          # 入力した国コードから祝日リストを取得し，LINEの応答メッセージとしてセットしてLINE上に返す．
+          client.reply_message(event['replyToken'], set_message(get_holidays(event.message['text'], '2020')))
         when Line::Bot::Event::MessageType::Image, Line::Bot::Event::MessageType::Video
           response = client.get_message_content(event.message['id'])
           tf = Tempfile.open("content")
@@ -52,5 +35,62 @@ class WebhookController < ApplicationController
       end
     }
     head :ok
+  end
+
+  private
+
+  # 返すテキストメッセージの設定
+  # レベル3でおそらく複数回使用するので残しています
+  def set_message(text)
+    {
+      type: 'text',
+      text: text
+    }
+  end
+
+  # 国コードと年に該当する祝日リストを返す
+  def get_holidays(countrycode, year, retry_count = 10)
+    raise ArgumentError, 'too many HTTP redirects' if retry_count == 0
+
+    begin
+      uri = URI.parse("https://date.nager.at/Api/v1/Get/#{countrycode}/#{year}")
+      holidays_list = ""    # returnする祝日リスト（改行タグで区切られた文字列）
+  
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        http.open_timeout = 5
+        http.read_timeout = 10
+        http.get(uri.request_uri)
+      end
+
+      case response
+        when Net::HTTPSuccess
+          holidays = JSON.parse(response.body)
+          # 祝日名のキー設定
+          if countrycode == 'JP'   # 日本なら日本語で返す
+            country = "localName"
+          else
+            country = "name"       # それ以外は英語で返す
+          end
+          holidays.each { |holiday|
+            holidays_list << "#{holiday["date"]}:#{holiday[country]}\n"
+          }
+          holidays_list.chomp!        # 最後の改行タグ削除
+          return holidays_list
+
+        when Net::HTTPRedirection
+          location = response['location']
+          Rails.logger.error(warn "redirected to #{location}")
+          get_holidays(countrycode, year, retry_count - 1)
+
+        else
+          Rails.logger.error([uri.to_s, response.value].join(" : "))
+          "HTTP接続エラーです。\nお手数ですが、運営元にお問い合わせください。"
+      end
+
+    rescue => e
+      Rails.logger.error(e.class)
+      Rails.logger.error(e.message)
+      "入力値が正しくありません"
+    end
   end
 end


### PR DESCRIPTION
## 実装の背景・目的

機能のアップデート
レベル2：国コードを入力するとその国の祝日リストを返す機能追加

## やったこと

- 国コードを入力するとその国の祝日リストを返す関数追加
- set_message()とget_holidays()はprivateに設定
- HTTP接続エラー時やURLとして不適切な入力があった際のエラー処理追加
- レベル1で行った固定メッセージを返す箇所削除

## キャプチャ

<img src="https://user-images.githubusercontent.com/48690396/77502947-a7113680-6e9f-11ea-8fee-c7f44e72066d.jpg" alt="lv2_screenshot" width="320px">

## 補足

- 敬老の日に'('がついているのは外部APIに登録されているデータのせいです．
