### PR TITLE
レベル3-1：国コードと年を入力するとその年のその国の祝日一覧を返す機能追加

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -26,7 +26,7 @@ class WebhookController < ApplicationController
       when Line::Bot::Event::Message
         case event.type
         when Line::Bot::Event::MessageType::Text
-          countrycode, year = return_countrycode_year(event.message['text'])
+          countrycode, year = return_countrycode_and_year(event.message['text'])
           if countrycode.nil?
             message = "入力フォーマットが正しくありません"
           else
@@ -60,7 +60,7 @@ class WebhookController < ApplicationController
   end
 
   # 入力フォーマットを判定し，国コードと年を返す
-  def return_countrycode_year(text)
+  def return_countrycode_and_year(text)
     case NKF.nkf('-w -Z1 -Z4', text)      # 全角はスペース含めてすべて半角にする
     when /([A-Za-z]{2})\s([0-9]{4})/      # フォーマット："国コード yyyy"
       countrycode, year = $1, $2

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -50,6 +50,8 @@ class WebhookController < ApplicationController
 
   MAX_RETRY_COUNT = 3
   API_URL = "https://date.nager.at/Api"
+  COUNTRY_CODE = /([A-Za-z]{2})/
+  YEAR = /([0-9]{4})/
 
   # 返すテキストメッセージの設定
   def generate_message(text)
@@ -62,9 +64,9 @@ class WebhookController < ApplicationController
   # 入力フォーマットを判定し，国コードと年を返す
   def return_countrycode_and_year(text)
     case NKF.nkf('-w -Z1 -Z4', text)      # 全角はスペース含めてすべて半角にする
-    when /([A-Za-z]{2})\s([0-9]{4})/      # フォーマット："国コード yyyy"
+    when /#{COUNTRY_CODE}\s*#{YEAR}/      # フォーマット："国コード yyyy"
       countrycode, year = $1, $2
-    when /([A-Za-z]{2})/                  # フォーマット："国コード"
+    when /#{COUNTRY_CODE}/                # フォーマット："国コード"
       countrycode, year = $1, Time.zone.today.year
     else
       countrycode, year = nil, nil 


### PR DESCRIPTION
## 実装の背景・目的

新機能の追加：特定の年での祝日リストを返す

## やったこと

- 入力フォーマットの判定処理追加
- 入力メッセージを処理して国コードと年を返すメソッド追加
- 国コードの判定（JPかどうか）に正規表現を適用

## キャプチャ

スクリーンショットなどがあれば
<img src="https://user-images.githubusercontent.com/48690396/77612092-9b3e7680-6f6a-11ea-98a7-97c8579d1f14.jpg" alt="lv3-1_screenshot" width="320px">


## 補足

- 複数スペースや全角にも対応してます
